### PR TITLE
adding dummy download link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,5 +4,6 @@
     <script src="https://unpkg.com/@microsoft/teams-js@1.3.1/dist/MicrosoftTeams.min.js" integrity="sha384-W0C47hvPMATrTnRWRl+rY3zESt3SJ7h5GnvMQx9wSgH44X2Xh5gieJ2hAXVeKSlo" crossorigin="anonymous"></script>
     <script src="./app.js"></script>
     <link href="./app.css" rel="stylesheet" />
+    <a href="/apps/placeholder_largeimage.png" download="appIcon">Download</a>
   </body>
 </html>


### PR DESCRIPTION
this will add a dummy link to trigger download note right now file path will not work.