### PR TITLE
Ensure that the repo uses the external NPM repo

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Problem

When a dev working on [microsoft-teams-test-tab](https://github.com/ydogandjiev/microsoft-teams-test-tab) has their terminal profile configured to use an internal NPM repo, running `npm i` may fail when a new package that exists in the public NPM repo doesn't yet exist in the internal NPM repo yet.

For example:

```
PS C:\Users\kimjason\projects\microsoft-teams-test-tab> npm i
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @microsoft/teams-js@2.35.0-beta.2.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in: C:\.tools\.npm\_logs\2025-03-31T20_44_59_202Z-debug-0.log
```

Solution

- Add .npmrc configured to use the external npm repo